### PR TITLE
Update bootstrap icons to latest version

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*!
 * Start Bootstrap - Landing Page v6.0.5 (https://startbootstrap.com/theme/landing-page)
-* Copyright 2013-2022 Start Bootstrap
+* Copyright 2013-2023 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-landing-page/blob/master/LICENSE)
 */
 /*!

--- a/dist/index.html
+++ b/dist/index.html
@@ -9,7 +9,7 @@
         <!-- Favicon-->
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
         <!-- Bootstrap icons-->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css" rel="stylesheet" type="text/css" />
         <!-- Google fonts-->
         <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css" />
         <!-- Core theme CSS (includes Bootstrap)-->

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -1,6 +1,6 @@
 /*!
 * Start Bootstrap - Landing Page v6.0.5 (https://startbootstrap.com/theme/landing-page)
-* Copyright 2013-2022 Start Bootstrap
+* Copyright 2013-2023 Start Bootstrap
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-landing-page/blob/master/LICENSE)
 */
 // This file is intentionally blank

--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -14,7 +14,7 @@ html(lang='en')
         link(rel='icon', type='image/x-icon', href='assets/favicon.ico')
 
         // Bootstrap icons
-        link(href='https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css', rel='stylesheet', type='text/css')
+        link(href='https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css', rel='stylesheet', type='text/css')
 
         // Google fonts
         link(href='https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic', rel='stylesheet', type='text/css')


### PR DESCRIPTION
I was trying to use some icons (QR code related specifically) that weren't present in that version of bootstrap icons. I'm updating it here.